### PR TITLE
[WIP] Symlinks

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -18,6 +18,7 @@ impl Node {
     pub const MODE_TYPE: u16 = 0xF000;
     pub const MODE_FILE: u16 = 0x8000;
     pub const MODE_DIR: u16 = 0x4000;
+    pub const MODE_SYMLINK: u16 = 0xA000;
 
     pub const MODE_PERM: u16 = 0x0FFF;
     pub const MODE_EXEC: u16 = 0o1;
@@ -72,6 +73,10 @@ impl Node {
 
     pub fn is_file(&self) -> bool {
         self.mode & Node::MODE_TYPE == Node::MODE_FILE
+    }
+
+    pub fn is_symlink(&self) -> bool {
+        self.mode & Node::MODE_TYPE == Node::MODE_SYMLINK
     }
 
     pub fn permission(&self, uid: u32, gid: u32, op: u16) -> bool {


### PR DESCRIPTION
There are still some things to be resolved, but does this seem like a good way to implement it?

My idea is that instead of adding system calls (`symlink` and `readlink`), symlinks can be opened with an `O_SYMLINK` flag to read where they point to, and created by opening with that flag and writing a path.

A limitation of the current implementation is that it only works with symlinks to the same scheme, but I don't think that should be the case. How should that be handled? It could be useful to have some way for `open()` to defer to another scheme.