### PR TITLE
Remove unneeded uses of 'mut'

### DIFF
--- a/mount/redox/scheme.rs
+++ b/mount/redox/scheme.rs
@@ -442,7 +442,7 @@ impl Scheme for FileScheme {
     fn read(&self, id: usize, buf: &mut [u8]) -> Result<usize> {
         // println!("Read {}, {:X} {}", id, buf.as_ptr() as usize, buf.len());
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.read(buf, &mut self.fs.borrow_mut())
         } else {
             Err(Error::new(EBADF))
@@ -452,7 +452,7 @@ impl Scheme for FileScheme {
     fn write(&self, id: usize, buf: &[u8]) -> Result<usize> {
         // println!("Write {}, {:X} {}", id, buf.as_ptr() as usize, buf.len());
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.write(buf, &mut self.fs.borrow_mut())
         } else {
             Err(Error::new(EBADF))
@@ -462,7 +462,7 @@ impl Scheme for FileScheme {
     fn seek(&self, id: usize, pos: usize, whence: usize) -> Result<usize> {
         // println!("Seek {}, {} {}", id, pos, whence);
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.seek(pos, whence, &mut self.fs.borrow_mut())
         } else {
             Err(Error::new(EBADF))
@@ -471,7 +471,7 @@ impl Scheme for FileScheme {
 
     fn fcntl(&self, id: usize, cmd: usize, arg: usize) -> Result<usize> {
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.fcntl(cmd, arg)
         } else {
             Err(Error::new(EBADF))
@@ -536,7 +536,7 @@ impl Scheme for FileScheme {
     fn fsync(&self, id: usize) -> Result<usize> {
         // println!("Fsync {}", id);
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.sync()
         } else {
             Err(Error::new(EBADF))
@@ -546,7 +546,7 @@ impl Scheme for FileScheme {
     fn ftruncate(&self, id: usize, len: usize) -> Result<usize> {
         // println!("Ftruncate {}, {}", id, len);
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.truncate(len, &mut self.fs.borrow_mut())
         } else {
             Err(Error::new(EBADF))
@@ -556,7 +556,7 @@ impl Scheme for FileScheme {
     fn futimens(&self, id: usize, times: &[TimeSpec]) -> Result<usize> {
         // println!("Futimens {}, {}", id, times.len());
         let mut files = self.files.lock();
-        if let Some(mut file) = files.get_mut(&id) {
+        if let Some(file) = files.get_mut(&id) {
             file.utimens(times, &mut self.fs.borrow_mut())
         } else {
             Err(Error::new(EBADF))

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -74,7 +74,7 @@ impl FileSystem {
         let free_block = self.header.1.free;
         let mut free = self.node(free_block)?;
         let mut block_option = None;
-        for mut extent in free.1.extents.iter_mut() {
+        for extent in free.1.extents.iter_mut() {
             if extent.length/512 >= length {
                 block_option = Some(extent.block);
                 extent.length -= length * 512;
@@ -159,7 +159,7 @@ impl FileSystem {
 
         let mut inserted = false;
         let mut parent = self.node(parent_block)?;
-        for mut extent in parent.1.extents.iter_mut() {
+        for extent in parent.1.extents.iter_mut() {
             if extent.length == 0 {
                 //New extent
                 inserted = true;
@@ -220,7 +220,7 @@ impl FileSystem {
         let mut removed = false;
         let mut replace_option = None;
         let mut parent = self.node(parent_block)?;
-        for mut extent in parent.1.extents.iter_mut() {
+        for extent in parent.1.extents.iter_mut() {
             if block >= extent.block && block + length <= extent.block + extent.length/512 {
                 //Inside
                 removed = true;
@@ -291,7 +291,7 @@ impl FileSystem {
         let mut changed = false;
 
         let mut node = self.node(block)?;
-        for mut extent in node.1.extents.iter_mut() {
+        for extent in node.1.extents.iter_mut() {
             if extent.length >= length {
                 length = 0;
                 break;
@@ -335,7 +335,7 @@ impl FileSystem {
         let mut changed = false;
 
         let mut node = self.node(block)?;
-        for mut extent in node.1.extents.iter_mut() {
+        for extent in node.1.extents.iter_mut() {
             if extent.length > length {
                 let start = (length + 511)/512;
                 let end = (extent.length + 511)/512;
@@ -420,7 +420,7 @@ impl FileSystem {
                 self.read_at(block, &mut sector)?;
 
                 let sector_size = min(sector.len() as u64, length) as usize;
-                for (s_b, mut b) in sector[byte_offset..sector_size].iter().zip(buf[i..].iter_mut()) {
+                for (s_b, b) in sector[byte_offset..sector_size].iter().zip(buf[i..].iter_mut()) {
                     *b = *s_b;
                     i += 1;
                 }
@@ -446,7 +446,7 @@ impl FileSystem {
                 self.read_at(block, &mut sector)?;
 
                 let sector_size = min(sector.len() as u64, length) as usize;
-                for (s_b, mut b) in sector[..sector_size].iter().zip(buf[i..].iter_mut()) {
+                for (s_b, b) in sector[..sector_size].iter().zip(buf[i..].iter_mut()) {
                     *b = *s_b;
                     i += 1;
                 }
@@ -481,7 +481,7 @@ impl FileSystem {
                 self.read_at(block, &mut sector)?;
 
                 let sector_size = min(sector.len() as u64, length) as usize;
-                for (mut s_b, b) in sector[byte_offset..sector_size].iter_mut().zip(buf[i..].iter()) {
+                for (s_b, b) in sector[byte_offset..sector_size].iter_mut().zip(buf[i..].iter()) {
                     *s_b = *b;
                     i += 1;
                 }
@@ -509,7 +509,7 @@ impl FileSystem {
                 self.read_at(block, &mut sector)?;
 
                 let sector_size = min(sector.len() as u64, length) as usize;
-                for (mut s_b, b) in sector[..sector_size].iter_mut().zip(buf[i..].iter()) {
+                for (s_b, b) in sector[..sector_size].iter_mut().zip(buf[i..].iter()) {
                     *s_b = *b;
                     i += 1;
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -47,7 +47,7 @@ impl Node {
 
     pub fn new(mode: u16, name: &str, parent: u64, ctime: u64, ctime_nsec: u32) -> Node {
         let mut bytes = [0; 222];
-        for (mut b, c) in bytes.iter_mut().zip(name.bytes()) {
+        for (b, c) in bytes.iter_mut().zip(name.bytes()) {
             *b = c;
         }
 


### PR DESCRIPTION
This seems to be a warning with the latest Rust, and an error due to #![deny(warnings)]