### PR TITLE
futimens: do not require O_RWONLY/O_RDWR

### DIFF
--- a/mount/redox/scheme.rs
+++ b/mount/redox/scheme.rs
@@ -253,7 +253,7 @@ impl Scheme for FileScheme {
                     0
                 };
 
-                Box::new(FileResource::new(path.to_string(), node.0, flags, seek))
+                Box::new(FileResource::new(path.to_string(), node.0, flags, seek, uid))
             },
             None => if flags & O_CREAT == O_CREAT {
                 let mut last_part = String::new();
@@ -293,7 +293,7 @@ impl Scheme for FileScheme {
                                 0
                             };
 
-                            Box::new(FileResource::new(path.to_string(), node.0, flags, seek))
+                            Box::new(FileResource::new(path.to_string(), node.0, flags, seek, uid))
                         }
                     } else {
                         return Err(Error::new(EPERM));


### PR DESCRIPTION
This code, for example, should work (and does on Linux).

```C
#include <sys/stat.h>
#include <fcntl.h>
#include <stdlib.h>
#include <stdio.h>

int main() {
    int fd = open("test.txt", O_RDONLY);
    struct timespec times[2] = {{0, 0}, {0, 0}};
    if (fd == -1) {
        perror("open");
        exit(1);
    }
    if (futimens(fd, times) == -1) {
        perror("futimens");
        exit(1);
    }
}
```

The specific situation where I came across this was code that `chmod`ed a file to be read only then set the times.